### PR TITLE
chore: refactor configuration management and remove dotenv assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,9 +53,6 @@ linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
 linux/flutter/ephemeral/.plugin_symlinks/rive_common
 linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
 
-# Local overrides with Envoy URLs - never commit (use dotenv_*.txt.example as template)
-/assets/dotenv_dev.txt
-/assets/dotenv_prd.txt
 ts/generate_go.sh
 pubspec.lock
 pubspec.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,8 @@ RUN mkdir $APP
 COPY . $APP
 WORKDIR $APP
 
-# Dotenv assets are gitignored; create from .example so build succeeds. Runtime uses config.json when deployed.
-RUN cp assets/dotenv_dev.txt.example assets/dotenv_dev.txt && \
-    cp assets/dotenv_prd.txt.example assets/dotenv_prd.txt
-RUN [ -f assets/dotenv_lcl.txt ] || touch assets/dotenv_lcl.txt
-
-# Build the Flutter web application
-RUN flutter clean
-RUN flutter pub get
+# API_URL is hardcoded in lib/config/api_url.dart; change when merging dev ↔ prod.
+RUN flutter clean && flutter pub get
 RUN flutter build web --verbose
 
 # Stage 2: Create the runtime environment with Nginx
@@ -56,9 +50,7 @@ COPY --from=build-env /app/build/web/ /usr/share/nginx/html/
 # Expose port 8080
 EXPOSE 8080
 
-# API_URL and other env are NOT available at build time. They are set by Cloud Run at
-# container start. entrypoint.sh reads them and writes /config.json; the app fetches that
-# in the browser. Set these in Cloud Run (or leave empty and use ENVIRONMENT + API_URL_PRD).
-ENV API_URL="" ENVIRONMENT="" API_URL_DEV="" API_URL_PRD="" LOCALE="fr"
+# API_URL is baked in at build via --build-arg. LOCALE can be set at runtime for entrypoint (config.json).
+ENV LOCALE="fr"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,30 +1,15 @@
 # weebi web-app
 
 ``` shell
-# main_local: uses dotenv_lcl.txt (localhost) – no setup
+# main_local or main: both use lib/config/api_url.dart (kApiUrl)
 flutter run -t lib/main_local.dart
 flutter run -d web-server -t lib/main_local.dart
-
-# main.dart with ENVIRONMENT: first-time setup required
-cp assets/dotenv_dev.txt.example assets/dotenv_dev.txt
-cp assets/dotenv_prd.txt.example assets/dotenv_prd.txt
-# Then add API_URL to each (obtain from team)
-flutter run --dart-define=ENVIRONMENT=development
-flutter run --dart-define=ENVIRONMENT=production
+flutter run
 ```
 
 ## Configuration
 
-The webapp calls the **Envoy proxy** (gRPC-Web), which forwards to weebi_server.
-
-**Two separate config paths** (no mixing):
-
-| Context | Source | See |
-|---------|--------|-----|
-| **Production** (Cloud Run) | Env vars → `/config.json` at startup | [SECRETS.md](SECRETS.md) |
-| **Local dev** | `assets/dotenv_*.txt` (gitignored) | [SECRETS.md](SECRETS.md) |
-
-Envoy URLs must **never** be committed. Use GitHub Secrets and Cloud Run Secret Manager.
+The webapp calls the **Envoy proxy** (gRPC-Web), which forwards to weebi_server. API_URL is set in `lib/config/api_url.dart` (`kApiUrl`). Change it when merging dev ↔ prod. See [SECRETS.md](SECRETS.md).
 
 ## issues
 

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -1,83 +1,27 @@
 # Secrets & Configuration
 
-Envoy proxy URLs and other sensitive values must **never** be committed. Configure them via:
+API_URL is **hardcoded** in `lib/config/api_url.dart`. Change it when merging between dev and prod (git merge triggers the build; no build args).
 
-- **Production (Cloud Run)**: Environment variables / Secret Manager
-- **CI/CD (GitHub Actions)**: Repository secrets
-- **Local development**: Gitignored dotenv files
+- **Deployed & local**: Uses `kApiUrl` from that file. Dev branch = dev URL, prod/main = prod URL.
 
 ---
 
-## Production (Google Cloud Run)
+## Hardcoded API_URL
 
-Set these as environment variables or [Secret Manager](https://cloud.google.com/secret-manager) references:
+**File:** `lib/config/api_url.dart`
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `API_URL` | Yes* | Envoy proxy URL (e.g. `https://weebi-envoyproxy-prd-xxx.run.app`) |
-| `API_URL_DEV` | If using ENVIRONMENT | Dev Envoy URL (use when `ENVIRONMENT=development`) |
-| `API_URL_PRD` | If using ENVIRONMENT | Prod Envoy URL (use when `ENVIRONMENT=production`) |
-| `ENVIRONMENT` | Optional | `development` or `production` – used to pick `API_URL_DEV` / `API_URL_PRD` |
-| `LOCALE` | No | Default locale (default: `fr`) |
+| Branch / env | Set `kApiUrl` to |
+|-------------|-------------------|
+| **Dev** | `https://weebi-envoyproxy-dev-29758828833.europe-west1.run.app` |
+| **Prod** | `https://weebi-envoyproxy-prd-29758828833.europe-west1.run.app` |
 
-\* Either set `API_URL` directly, or set `ENVIRONMENT` + `API_URL_DEV`/`API_URL_PRD`.
-
-**Troubleshooting 405 on gRPC:** If the app sends POST to the *webapp* host (e.g. `webapp.dev.weebi.com/weebi..../authenticateWithCredentials`) and nginx returns 405, `API_URL` is empty at runtime. Set `API_URL` (or `ENVIRONMENT` + `API_URL_DEV`/`API_URL_PRD`) on the **webapp** Cloud Run service for that environment and deploy a new revision so `config.json` gets the Envoy URL.
-
-**Example (direct URL):**
-```bash
-gcloud run deploy weebi-webapp --set-secrets "API_URL=envoy-url-prd:latest"
-```
-
-**Example (via ENVIRONMENT + secrets):**
-```bash
-gcloud run deploy weebi-webapp \
-  --set-env-vars "ENVIRONMENT=production" \
-  --set-secrets "API_URL_PRD=envoy-url-prd:latest"
-```
+When you merge dev → prod (or prod → dev), update this constant so the built app points to the correct Envoy. Merge then triggers the build with the right URL.
 
 ---
 
-## GitHub Actions / CI
+## Config flow summary
 
-Add these as [repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets):
-
-| Secret | Description |
-|--------|-------------|
-| `API_URL` | Envoy proxy URL for the deployed environment |
-| `API_URL_DEV` | Dev Envoy URL (if building for dev) |
-| `API_URL_PRD` | Prod Envoy URL (if building for prod) |
-
-Use them when building/deploying:
-```yaml
-env:
-  API_URL: ${{ secrets.API_URL_PRD }}
-```
-
----
-
-## Local Development
-
-1. Copy the example files:
-   ```bash
-   cp assets/dotenv_dev.txt.example assets/dotenv_dev.txt
-   cp assets/dotenv_prd.txt.example assets/dotenv_prd.txt
-   ```
-
-2. Obtain the Envoy URL from your team and add it to `assets/dotenv_dev.txt`:
-   ```
-   API_URL=https://your-envoy-url.run.app
-   LOCALE=fr
-   ```
-
-3. **Do not commit** `dotenv_dev.txt` or `dotenv_prd.txt` – they are gitignored.
-
----
-
-## Config Flow Summary
-
-| Context | Config source | Secrets from |
-|---------|---------------|--------------|
-| **Cloud Run** | `/config.json` (generated at startup) | Env vars / Secret Manager |
-| **Local `flutter run`** | `assets/dotenv_*.txt` | Local files (gitignored) |
-| **Docker build** | Uses `.example` files (empty URLs) | N/A – runtime uses env vars |
+| Context | API_URL source |
+|---------|----------------|
+| **All** | `lib/config/api_url.dart` (`kApiUrl`). Change when merging dev ↔ prod. |
+| **Fallback** | If `kApiUrl` empty: config.json (then empty). |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,28 +1,8 @@
 #!/bin/sh
-# Cloud Run sets API_URL (and optionally ENVIRONMENT, API_URL_DEV/API_URL_PRD) at runtime.
-# We write them into config.json so the Flutter app (running in the browser) can fetch it.
-# The app cannot read server env vars; config.json is the only way to pass them in.
-# See SECRETS.md for GitHub Actions and Cloud Run setup.
+# API_URL is set at build time (--build-arg API_URL=...) per env. We still write config.json for optional use.
+# See SECRETS.md for build-arg and CI setup.
 
 CONFIG_FILE="/usr/share/nginx/html/config.json"
-
-API_URL="${API_URL:-}"
 LOCALE="${LOCALE:-fr}"
-
-# If API_URL not set, derive from ENVIRONMENT + API_URL_DEV/API_URL_PRD (set as secrets)
-if [ -z "$API_URL" ] && [ -n "$ENVIRONMENT" ]; then
-  case "$ENVIRONMENT" in
-    production|prd)
-      API_URL="${API_URL_PRD:-}"
-      ;;
-    development|dev)
-      API_URL="${API_URL_DEV:-}"
-      ;;
-    *)
-      API_URL="${API_URL_DEV:-}"
-      ;;
-  esac
-fi
-
-echo "{\"API_URL\":\"${API_URL}\",\"LOCALE\":\"${LOCALE}\"}" > "$CONFIG_FILE"
+echo "{\"API_URL\":\"\",\"LOCALE\":\"${LOCALE}\"}" > "$CONFIG_FILE"
 exec nginx -g "daemon off;"

--- a/lib/config/api_url.dart
+++ b/lib/config/api_url.dart
@@ -1,0 +1,4 @@
+/// Envoy proxy URL for gRPC. Change this when merging between dev and prod.
+/// - Dev branch: use weebi-envoyproxy-dev-... run.app
+/// - Prod / main: use weebi-envoyproxy-prd-... run.app
+const String kApiUrl = 'https://weebi-envoyproxy-dev-29758828833.europe-west1.run.app';

--- a/lib/config_loader.dart
+++ b/lib/config_loader.dart
@@ -1,35 +1,30 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-
+import 'config/api_url.dart';
 import 'config_loader_web.dart' if (dart.library.io) 'config_loader_stub.dart'
     as config_fetcher;
 import 'environment.dart';
 
-/// Loads configuration: config.json first (deployed), then dotenv fallback (local dev when no config.json).
+/// Loads configuration. Order: hardcoded kApiUrl → config.json. Change lib/config/api_url.dart when merging dev ↔ prod.
 Future<void> loadConfig() async {
+  // 1) Hardcoded (set per branch; merge triggers build with correct URL)
+  if (kApiUrl.isNotEmpty) {
+    Config.init(apiUrl: kApiUrl, locale: 'fr');
+    return;
+  }
+
+  // 2) Runtime fetch (optional)
   try {
     final configJson = await config_fetcher.fetchConfigJson();
     if (configJson != null && configJson.isNotEmpty) {
       final map = jsonDecode(configJson) as Map<String, dynamic>;
-      final apiUrl = (map['API_URL'] as String?) ?? '';
-      final locale = (map['LOCALE'] as String?) ?? 'fr';
-      Config.init(apiUrl: apiUrl, locale: locale);
-      debugPrint('[weebi] config.json loaded → API_URL=${apiUrl.isEmpty ? "(empty)" : apiUrl}');
+      Config.init(
+        apiUrl: (map['API_URL'] as String?) ?? '',
+        locale: (map['LOCALE'] as String?) ?? 'fr',
+      );
       return;
     }
   } catch (_) {}
 
-  // Fallback: dotenv (local dev; or when config.json missing/failed/empty)
-  const environment =
-      String.fromEnvironment('ENVIRONMENT', defaultValue: 'development');
-  if (environment == 'development') {
-    await dotenv.load(fileName: 'assets/dotenv_dev.txt');
-  } else {
-    await dotenv.load(fileName: 'assets/dotenv_prd.txt');
-  }
-  final apiUrl = dotenv.env['API_URL'] ?? '';
-  Config.init(apiUrl: apiUrl, locale: dotenv.env['LOCALE'] ?? 'fr');
-  debugPrint('[weebi] dotenv fallback ($environment) → API_URL=${apiUrl.isEmpty ? "(empty)" : apiUrl}');
+  Config.init(apiUrl: '', locale: 'fr');
 }

--- a/lib/config_loader_stub.dart
+++ b/lib/config_loader_stub.dart
@@ -1,2 +1,2 @@
-/// Stub for non-web platforms (returns null - dotenv fallback will be used).
+/// Stub for non-web platforms (returns null).
 Future<String?> fetchConfigJson() async => null;

--- a/lib/config_loader_web.dart
+++ b/lib/config_loader_web.dart
@@ -1,22 +1,10 @@
 import 'dart:html' as html;
 
-import 'package:flutter/foundation.dart';
-
-/// Fetches /config.json from the same origin (used in production Docker).
-/// Cache-busting so browser doesn't use a stale config (e.g. with empty API_URL).
+/// Fetches /config.json from same origin (used when API_URL is not set at build time).
 Future<String?> fetchConfigJson() async {
-  final uri = Uri.base
-      .resolve('/config.json')
-      .replace(queryParameters: {'_': '${DateTime.now().millisecondsSinceEpoch}'});
+  final uri = Uri.base.resolve('/config.json');
   final response = await html.window.fetch(uri.toString());
-  if (response.status != 200) {
-    debugPrint('[weebi] config.json status=${response.status} → fallback to dotenv');
-    return null;
-  }
+  if (response.status != 200) return null;
   final text = await response.text();
-  if (text.isEmpty) {
-    debugPrint('[weebi] config.json 200 but empty body → fallback to dotenv');
-    return null;
-  }
-  return text;
+  return text.isEmpty ? null : text;
 }

--- a/lib/environment.dart
+++ b/lib/environment.dart
@@ -1,5 +1,3 @@
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-
 class Config {
   static String _apiUrl = '';
   static String _locale = '';
@@ -7,15 +5,8 @@ class Config {
   static String get apiUrl => _apiUrl;
   static String get locale => _locale;
 
-  /// Initialize from runtime config (config.json) or dotenv.
   static void init({required String apiUrl, required String locale}) {
     _apiUrl = apiUrl;
     _locale = locale.isNotEmpty ? locale : 'fr';
-  }
-
-  /// Legacy: init from dotenv when used before loadConfig (e.g. tests).
-  static void initFromDotenv() {
-    _apiUrl = dotenv.env['API_URL'] ?? '';
-    _locale = dotenv.env['LOCALE'] ?? 'fr';
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,6 @@ import 'package:web_admin/shared_prefs.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Load config: /config.json in production (from env vars), dotenv in dev
   await loadConfig();
 
   runApp(const SharedPrefsFetchWidget(child: RootApp()));

--- a/lib/main_local.dart
+++ b/lib/main_local.dart
@@ -1,17 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:web_admin/environment.dart';
+import 'package:web_admin/config_loader.dart';
 import 'package:web_admin/root_app.dart';
 import 'package:web_admin/shared_prefs.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
-  await dotenv.load(fileName: "assets/dotenv_lcl.txt");
-  Config.init(
-    apiUrl: dotenv.env['API_URL'] ?? '',
-    locale: dotenv.env['LOCALE'] ?? 'fr',
-  );
-
+  await loadConfig();
   runApp(const SharedPrefsFetchWidget(child: RootApp()));
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,6 @@ dependencies:
   file_picker: ^8.0.0
 
   grpc: ^4.0.1 # grpc_web not exported from protos_weebi
-  flutter_dotenv: ^5.2.1
 
   package_info_plus: ^8.3.1
 
@@ -55,9 +54,6 @@ flutter:
 
   assets:
     - assets/images/app_logo.png
-    - assets/dotenv_lcl.txt
-    - assets/dotenv_dev.txt
-    - assets/dotenv_prd.txt
 
   # fonts:
   #   - family: Schyler

--- a/web/index.html
+++ b/web/index.html
@@ -33,7 +33,6 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
-  <!-- defer keeps load order; async can cause makeFlutterFactory LateInitializationError -->
   <script src="flutter_bootstrap.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
- Removed dotenv_dev.txt and dotenv_prd.txt from .gitignore and assets, streamlining the configuration process.
- Updated Dockerfile to eliminate the creation of dotenv files, relying on a hardcoded API_URL in lib/config/api_url.dart.
- Enhanced config loading logic to prioritize the hardcoded API_URL and simplify fallback mechanisms.
- Adjusted README and SECRETS documentation to reflect the new configuration approach.